### PR TITLE
Mark comment as spam even it's moved to thrash after inserting comment

### DIFF
--- a/inc/cleantalk-public.php
+++ b/inc/cleantalk-public.php
@@ -1134,8 +1134,10 @@ function ct_preprocess_comment($comment) {
 		if($ct_result->spam == 3) // Don't move to spam folder. Delete.
 			wp_die($err_text, 'Blacklisted', array('back_link' => true));
 			
-		if($ct_result->spam == 2)
+		if($ct_result->spam == 2) {
+			add_filter('pre_comment_approved', 'ct_set_comment_spam', 997, 2);
 			add_action('comment_post', 'ct_wp_trash_comment', 997, 2);
+		}
 		
 		if($ct_result->spam == 1)
 			add_filter('pre_comment_approved', 'ct_set_comment_spam', 997, 2);


### PR DESCRIPTION
HI,

If the comment is not marked as spam before it's moved to thrash, it causes issues for plugins using check of the approval status. In our case, the plugin notifying users about new comments and plugin posting the comments directly to forums were failing without this fix.

Currently, the $approved variable is set to 0, instead of 'spam'. 

Could you please release next version with our changes?

Thanks,
Richard
Foliovision