### PR TITLE
Add note when Gravity Forms entry is marked as spam

### DIFF
--- a/inc/cleantalk-public-integrations.php
+++ b/inc/cleantalk-public-integrations.php
@@ -2450,6 +2450,7 @@ function apbct_form__gravityForms__testSpam($is_spam, $_form, $entry) {
 		$is_spam = true;
 		$ct_gform_is_spam = true;
 		$ct_gform_response = $ct_result->comment;
+		add_action( 'gform_entry_created', 'apbct_form__gravityForms__add_entry_note' );
 	}
 
 	return $is_spam;
@@ -2464,6 +2465,19 @@ function apbct_form__gravityForms__showResponse( $confirmation, $form, $_entry, 
 	}
 
 	return $confirmation;
+}
+
+/**
+ * Adds a note to the entry once the spam status is set (GF 2.4.18+).
+ *
+ * @param array $entry The entry that was created.
+ */
+function apbct_form__gravityForms__add_entry_note( $entry ) {
+	if ( rgar( $entry, 'status' ) !== 'spam' || ! method_exists( 'GFAPI', 'add_note' ) ) {
+		return;
+	}
+
+	GFAPI::add_note( $entry['id'], 0, 'CleanTalk', __( 'This entry has been marked as spam.', 'cleantalk-spam-protect' ), 'cleantalk', 'success' );
 }
 
 /**

--- a/inc/cleantalk-public-integrations.php
+++ b/inc/cleantalk-public-integrations.php
@@ -2407,6 +2407,7 @@ function apbct_form__gravityForms__testSpam($is_spam, $_form, $entry) {
 	global $apbct, $cleantalk_executed, $ct_gform_is_spam, $ct_gform_response;
 
 	if (
+		$is_spam ||
 		$apbct->settings['forms__contact_forms_test'] == 0 ||
 		$cleantalk_executed // Return unchanged result if the submission was already tested.
 	) {


### PR DESCRIPTION
:wave: Gravity Forms here

Could we ask you to add a note to the entry when it is marked as spam to help identify which plugin performed the spam check? Here's what it would look like in the notes section of the entry detail page:

![Screenshot 2021-07-23 at 15 16 46](https://user-images.githubusercontent.com/1872371/126796400-c9868d99-c040-4022-9899-0e94467cd4c9.png)
