### PR TITLE
Update Cookie.php class - HTTPS fixes

### DIFF
--- a/lib/Cleantalk/ApbctWP/Variables/Cookie.php
+++ b/lib/Cleantalk/ApbctWP/Variables/Cookie.php
@@ -116,9 +116,9 @@ class Cookie extends \Cleantalk\Variables\Cookie
         $httponly = false,
         $samesite = 'Lax'
     ) {
+        $secure = !is_null($secure) ? $secure : !in_array(Server::get('HTTPS'), ['off', ''], false) || Server::get('SERVER_PORT') == 443;
         // For PHP 7.3+ and above
         if (version_compare(phpversion(), '7.3.0', '>=')) {
-            $secure = ! is_null($secure) ? $secure : Server::get('HTTPS') || Server::get('SERVER_PORT') == 443;
 
             $params = array(
                 'expires' => $expires,

--- a/lib/Cleantalk/ApbctWP/Variables/Cookie.php
+++ b/lib/Cleantalk/ApbctWP/Variables/Cookie.php
@@ -116,10 +116,9 @@ class Cookie extends \Cleantalk\Variables\Cookie
         $httponly = false,
         $samesite = 'Lax'
     ) {
-        $secure = !is_null($secure) ? $secure : !in_array(Server::get('HTTPS'), ['off', ''], false) || Server::get('SERVER_PORT') == 443;
+        $secure = ! is_null($secure) ? $secure : ! in_array(Server::get('HTTPS'), ['off', '']) || Server::get('SERVER_PORT') == 443;
         // For PHP 7.3+ and above
-        if (version_compare(phpversion(), '7.3.0', '>=')) {
-
+        if ( version_compare(phpversion(), '7.3.0', '>=') ) {
             $params = array(
                 'expires' => $expires,
                 'path' => $path,

--- a/lib/Cleantalk/Variables/Cookie.php
+++ b/lib/Cleantalk/Variables/Cookie.php
@@ -70,7 +70,7 @@ class Cookie extends ServerVariables
         $httponly = false,
         $samesite = 'Lax'
     ) {
-        $secure = ! is_null($secure) ? $secure : Server::get('HTTPS') !== 'off' || Server::get('SERVER_PORT') == 443;
+        $secure = ! is_null($secure) ? $secure : ! in_array(Server::get('HTTPS'), ['off', '']) || Server::get('SERVER_PORT') == 443;
 
         // For PHP 7.3+ and above
         if ( version_compare(phpversion(), '7.3.0', '>=') ) {

--- a/lib/Cleantalk/Variables/Cookie.php
+++ b/lib/Cleantalk/Variables/Cookie.php
@@ -73,7 +73,7 @@ class Cookie extends ServerVariables
         $secure = ! is_null($secure) ? $secure : Server::get('HTTPS') !== 'off' || Server::get('SERVER_PORT') == 443;
 
         // For PHP 7.3+ and above
-        if (version_compare(phpversion(), '7.3.0', '>=')) {
+        if ( version_compare(phpversion(), '7.3.0', '>=') ) {
             $params = array(
                 'expires' => $expires,
                 'path' => $path,


### PR DESCRIPTION
1. Why do we approve to set null secure statement for 5.6-7.2? Extracted this before php version check.
2. Server::get('HTTPS') answers now compared with off and empty string instead of bool