### PR TITLE
Fix Array to string conversion warning in AltSessions.php

### DIFF
--- a/lib/Cleantalk/ApbctWP/Variables/AltSessions.php
+++ b/lib/Cleantalk/ApbctWP/Variables/AltSessions.php
@@ -224,7 +224,7 @@ class AltSessions
                     $cookies_array[$name] = (bool)$value;
                     break;
                 case 'string':
-                    $cookies_array[$name] = (string)$value;
+                    $cookies_array[$name] = is_array($value) ? wp_json_encode($value) : (string)$value;
                     break;
                 case 'json':
                     if ( ! is_string($value) || json_decode($value) === null ) {


### PR DESCRIPTION
## Summary

Fixes #765

When a cookie value is an array and the expected type annotation is `string`, the `(string)$value` cast on line 227 triggers a PHP "Array to string conversion" warning on every `POST /wp-json/cleantalk-antispam/v1/alt_sessions` request.

## Change

Added an `is_array()` check before the cast. Array values are JSON-encoded via `wp_json_encode()` instead of cast directly.

```php
// Before
$cookies_array[$name] = (string)$value;

// After
$cookies_array[$name] = is_array($value) ? wp_json_encode($value) : (string)$value;
```